### PR TITLE
Upgrade to `blowfish2`

### DIFF
--- a/ftplugin/vault.vim
+++ b/ftplugin/vault.vim
@@ -10,7 +10,7 @@ setlocal textwidth=80
 setlocal formatlistpat="^\s*[\d*-]\+[\]:.)}\t ]\s*"
 setlocal foldexpr=VaultFoldLevel(v:lnum)
 setlocal foldmethod=expr
-setlocal cryptmethod=blowfish
+setlocal cryptmethod=blowfish2
 set foldtext=v:folddashes.substitute(getline(v:foldstart),'==','','g')
 
 let g:vault_password_command = 'pwgen -c -n -1 10'


### PR DESCRIPTION
On Vim 7.4, opening a file that has been encrypted with `blowfish` shows
a warning. Looking at `:help 'cm'` this is because `blowfish` has a
security flaw and is recommended to use `blowfish2` instead.
